### PR TITLE
Dppvfx dev (continued)

### DIFF
--- a/docs/bibliography/biblio.bib
+++ b/docs/bibliography/biblio.bib
@@ -118,6 +118,13 @@ title = {{Rates of Convergence for Sparse Variational Gaussian Process Regressio
 url = {http://proceedings.mlr.press/v97/burt19a.html},
 year = {2019}
 }
+@inproceedings{CaLaVa17,
+  title={Distributed Adaptive Sampling for Kernel Matrix Approximation},
+  author={Calandriello, Daniele and Lazaric, Alessandro and Valko, Michal},
+  booktitle={Artificial Intelligence and Statistics},
+  pages={1421--1429},
+  year={2017}
+}
 @book{DaVe03,
 address = {New York, USA},
 author = {Daley, Daryl J. and Vere-Jones, David},
@@ -655,6 +662,13 @@ publisher = {MIT Press},
 title = {{Gaussian processes for machine learning}},
 url = {http://www.gaussianprocess.org/gpml/},
 year = {2006}
+}
+@inproceedings{RuCaCaRo18,
+  title={On fast leverage score sampling and optimal learning},
+  author={Rudi, Alessandro and Calandriello, Daniele and Carratino, Luigi and Rosasco, Lorenzo},
+  booktitle={Advances in Neural Information Processing Systems},
+  pages={5672--5682},
+  year={2018}
 }
 @article{Sos00,
 abstract = {The paper contains an exposition of recent as well as old enough results on determinantal random point fields. We start with some general theorems including the proofs of the necessary and sufficient condition for the existence of the determinantal random point field with Hermitian kernel and a criterion for the weak convergence of its distribution. In the second section we proceed with the examples of the determinantal random point fields from Quantum Mechanics, Statistical Mechanics, Random Matrix Theory, Probability Theory, Representation Theory and Ergodic Theory. In connection with the Theory of Renewal Processes we characterize all determinantal random point fields in R{\^{}}1 and Z{\^{}}1 with independent identically distributed spacings. In the third section we study the translation invariant determinantal random point fields and prove the mixing property of any multiplicity and the absolute continuity of the spectra. In the fourth (and the last) section we discuss the proofs of the Central Limit Theorem for the number of particles in the growing box and the Functional Central Limit Theorem for the empirical distribution function of spacings.},

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -245,7 +245,7 @@ class FiniteDPP:
         self.list_of_samples = []
 
     # Exact sampling
-    def sample_exact(self, mode='GS', random_state=None):
+    def sample_exact(self, mode='GS', random_state=None, **params):
         """ Sample exactly from the corresponding :class:`FiniteDPP <FiniteDPP>` object. The sampling scheme is based on the chain rule with Gram-Schmidt like updates of the conditionals.
 
         :param mode:
@@ -359,7 +359,7 @@ class FiniteDPP:
 
             self.sample_exact(self.sampling_mode, random_state=rng)
 
-    def sample_exact_k_dpp(self, size, mode='GS', random_state=None):
+    def sample_exact_k_dpp(self, size, mode='GS', random_state=None, **params):
         """ Sample exactly from :math:`\\operatorname{k-DPP}`.
         A priori the :class:`FiniteDPP <FiniteDPP>` object was instanciated by its likelihood :math:`\\mathbf{L}` kernel so that
 

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -413,7 +413,7 @@ class FiniteDPP:
                     rank = np.round(np.trace(self.K)).astype(int)
 
                 if size != rank:
-                    raise ValueError('size k={} != rank={} for projection correlation K kernel'.format(k, rank))
+                    raise ValueError('size k={} != rank={} for projection correlation K kernel'.format(size, rank))
 
                 if self.K_eig_vals is not None:
                     # K_eig_vals > 0.5 below to get indices where e_vals = 1

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -57,16 +57,14 @@ from dppy.utils import (check_random_state,
 class FiniteDPP:
     """ Finite DPP object parametrized by
 
-    :param kernel_type:
+    :param string kernel_type:
 
         - ``'correlation'`` :math:`\\mathbf{K}` kernel
         - ``'likelihood'`` :math:`\\mathbf{L}` kernel
 
-    :type kernel_type:
-        string
-
     :param projection:
-        Indicate whether the provided kernel is of projection type. This may be useful when the :class:`FiniteDPP` object is defined through its correlation kernel :math:`\\mathbf{K}`.
+        Indicate whether the provided kernel is of projection type. This may be useful when the
+        :class:`FiniteDPP` object is defined through its correlation kernel :math:`\\mathbf{K}`.
 
     :type projection:
         bool, default ``False``
@@ -85,13 +83,17 @@ class FiniteDPP:
             - ``{'L': L}``, with :math:`\\mathbf{L}\\succeq 0`
             - ``{'L_eig_dec': (eig_vals, eig_vecs)}``, with :math:`eigvals \\geq 0`
             - ``{'L_gram_factor': Phi}``, with :math:`\\mathbf{L} = \\Phi^{ \\top} \\Phi`
+            - ``{'L_eval_X_data': (eval_L, X_data)}``, with :math:`\mathbf{X}_{data}(N \\times d)` and
+              :math:`eval \_ L` a likelihood function such that
+              :math:`\mathbf{L} = eval \_ L(\mathbf{X}_{data}, \mathbf{X}_{data})`
+
 
     :type params:
         dict
 
     .. caution::
 
-        For now we only consider real valued matrices :math:`\\mathbf{K}, \\mathbf{L}, A, \\Phi`.
+        For now we only consider real valued matrices :math:`\\mathbf{K}, \\mathbf{L}, A, \\Phi, \mathbf{X}_{data}`.
 
     .. seealso::
 
@@ -171,6 +173,9 @@ class FiniteDPP:
 
         if self.eval_L and not callable(self.eval_L):
             raise ValueError('eval_L should be a likelihood function between points')
+        if self.X_data and (self.X_data.size == 0 or self.X_data.ndims != 2):
+            raise ValueError('The provided data matrix seems empty or with the wrong shape.'
+                             ' For data with n elements and d features, X_data should be an (n x m) ndarray.')
 
 
     def __str__(self):
@@ -400,10 +405,8 @@ class FiniteDPP:
             \\mathbb{P}_{\\operatorname{k-DPP}}(\\mathcal{X} = S)
                 \\propto \\det \\mathbf{L}_S ~ 1_{|S|=k}
 
-        :param size:
+        :param int size:
             size :math:`k` of the :math:`\\operatorname{k-DPP}`
-        :type size:
-            int
 
         :param mode:
             - ``projection=True``:
@@ -594,17 +597,14 @@ class FiniteDPP:
     def sample_mcmc(self, mode, **params):
         """ Run a MCMC with stationary distribution the corresponding :class:`FiniteDPP <FiniteDPP>` object.
 
-        :param mode:
+        :param string mode:
 
             - ``'AED'`` Add-Exchange-Delete
             - ``'AD'`` Add-Delete
             - ``'E'`` Exchange
             - ``'zonotope'`` Zonotope sampling
 
-        :type mode:
-            string
-
-        :param params:
+        :param dict params:
             Dictionary containing the parameters for MCMC samplers with keys
 
             ``'random_state'`` (default None)
@@ -624,9 +624,6 @@ class FiniteDPP:
                 + ``'x_0'`` initial point in zonotope (default A*u, u~U[0,1]^n)
                 + ``'nb_iter'`` (default 10) Number of iterations of the chain
                 + ``'T_max'`` (default None) Time horizon
-
-        :type params:
-            dict
 
         :return:
             A sample from the corresponding :class:`FiniteDPP <FiniteDPP>` object.

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -315,11 +315,11 @@ class FiniteDPP:
                 self.intermediate_sample_info = self.intermediate_sample_info._replace(
                                                                             q=q_func(self.intermediate_sample_info.s))
 
-            sample, rej_count = vfx_sampling_do_sampling_loop(self.X,
+            sampl, rej_count = vfx_sampling_do_sampling_loop(self.X,
                                                          self.eval_L,
                                                          self.intermediate_sample_info,
                                                          rng)
-            self.list_of_samples.append(sample)
+            self.list_of_samples.append(sampl)
 
         # If eigen decoposition of K, L or L_dual is available USE IT!
         elif self.K_eig_vals is not None:
@@ -489,6 +489,30 @@ class FiniteDPP:
                                                     random_state=rng)
 
             self.size_k_dpp = size
+            self.list_of_samples.append(sampl)
+
+        elif self.sampling_mode == 'vfx':
+            if (self.intermediate_sample_info is None
+                    or self.intermediate_sample_info.s != size):
+                self.intermediate_sample_info = vfx_sampling_precompute_constants(
+                    X = self.X,
+                    eval_L=self.eval_L,
+                    desired_s=size,
+                    rng = rng,
+                    **params
+                )
+
+                q_func = params.get('q_func', lambda s: s * s)
+                self.intermediate_sample_info = self.intermediate_sample_info._replace(
+                    q=q_func(self.intermediate_sample_info.s))
+
+            sampl = []
+            while len(sampl) != size:
+                sampl, rej_count = vfx_sampling_do_sampling_loop(self.X,
+                                                                  self.eval_L,
+                                                                  self.intermediate_sample_info,
+                                                                  rng)
+
             self.list_of_samples.append(sampl)
 
         # If eigen decoposition of K, L or L_dual is available USE IT!

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -165,7 +165,8 @@ class FiniteDPP:
 
         # L likelihood function representation
         # eval_L(X, Y) = L(X, Y)
-        self.eval_L, self.X = params.get('L_eval_data', [None, None])
+        # eval_L(X) = L(X, X)
+        self.eval_L, self.X_data = params.get('L_eval_X_data', [None, None])
         self.intermediate_sample_info = None
 
         if self.eval_L and not callable(self.eval_L):

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -312,7 +312,8 @@ class FiniteDPP:
                 )
 
                 q_func = params.get('q_func', lambda s: s * s)
-                self.intermediate_sample_info.q = q_func(self.intermediate_sample_info.s)
+                self.intermediate_sample_info = self.intermediate_sample_info._replace(
+                                                                            q=q_func(self.intermediate_sample_info.s))
 
             sample, rej_count = vfx_sampling_do_sampling_loop(self.X,
                                                          self.eval_L,

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -163,7 +163,7 @@ class FiniteDPP:
                     self.L = Phi.T.dot(Phi)
                     print('L = Phi.T Phi was computed: Phi (dxN) with d>=N')
 
-        # L "lazy" likelihood function representation
+        # L likelihood function representation
         # eval_L(X, Y) = L(X, Y)
         self.eval_L, self.X = params.get('L_eval_data', [None, None])
         self.intermediate_sample_info = None
@@ -191,7 +191,7 @@ class FiniteDPP:
         # kernel_type, projection and params.
 
         K_type, K_params = 'correlation', {'K', 'K_eig_dec', 'A_zono'}
-        L_type, L_params = 'likelihood', {'L', 'L_eig_dec', 'L_gram_factor', 'L_eval_data'}
+        L_type, L_params = 'likelihood', {'L', 'L_eig_dec', 'L_gram_factor', 'L_eval_X_data'}
 
         if self.kernel_type == K_type:
             if self.params_keys.intersection(K_params):
@@ -217,7 +217,7 @@ class FiniteDPP:
                      '- `L` = L >= 0',
                      '- `L_eig_dec` = (eig_vals, eig_vecs) eig_vals >= 0',
                      '- `L_gram_factor` = Phi (dxN) where L = Phi.T Phi',
-                     '- `L_eval_data` = (eval_L, X)',
+                     '- `L_eval_X_data` = (eval_L, X_data)',
                      'Given: {}'.format(self.params_keys)]
                 raise ValueError('\n'.join(err_print))
 
@@ -305,7 +305,7 @@ class FiniteDPP:
         elif self.sampling_mode == 'vfx':
             if self.intermediate_sample_info is None:
                 self.intermediate_sample_info = vfx_sampling_precompute_constants(
-                    X = self.X,
+                    X = self.X_data,
                     eval_L=self.eval_L,
                     rng = rng,
                     **params
@@ -315,7 +315,7 @@ class FiniteDPP:
                 self.intermediate_sample_info = self.intermediate_sample_info._replace(
                                                                             q=q_func(self.intermediate_sample_info.s))
 
-            sampl, rej_count = vfx_sampling_do_sampling_loop(self.X,
+            sampl, rej_count = vfx_sampling_do_sampling_loop(self.X_data,
                                                          self.eval_L,
                                                          self.intermediate_sample_info,
                                                          rng)

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -385,6 +385,10 @@ class FiniteDPP:
             self.eig_vecs, _ = la.qr(self.A_zono.T, mode='economic')
 
             self.sample_exact(self.sampling_mode, random_state=rng)
+        else:
+            raise ValueError('None of the available samplers could be used based on the current DPP representation.'
+                             ' This should never happen, please consider rasing an issue on github'
+                             ' at https://github.com/guilgautier/DPPy/issues')
 
     def sample_exact_k_dpp(self, size, mode='GS', random_state=None, **params):
         """ Sample exactly from :math:`\\operatorname{k-DPP}`.
@@ -572,6 +576,10 @@ class FiniteDPP:
             self.L_eig_vals, self.eig_vecs = la.eigh(self.L)
             self.sample_exact_k_dpp(size, self.sampling_mode,
                                     random_state=rng)
+        else:
+            raise ValueError('None of the available samplers could be used based on the current DPP representation.'
+                             ' This should never happen, please consider rasing an issue on github'
+                             ' at https://github.com/guilgautier/DPPy/issues')
 
     # Approximate sampling
     def sample_mcmc(self, mode, **params):

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -303,6 +303,9 @@ class FiniteDPP:
             self.list_of_samples.append(sampl)
 
         elif self.sampling_mode == 'vfx':
+            if self.eval_L is None or self.X_data is None:
+                raise ValueError("The vfx sampler is currently only available for the 'L_eval_X_data' representation.")
+
             if self.intermediate_sample_info is None:
                 self.intermediate_sample_info = vfx_sampling_precompute_constants(
                     X = self.X_data,
@@ -690,9 +693,8 @@ class FiniteDPP:
             pass
 
         elif self.eval_L is not None:
-            err_print = ['K kernel cannot be computed:',
-                         'no K representation provided, and',
-                         'L is provided in lazy mode and likely would not fit in memory']
+            err_print = ['Computing the K kernel is currently not supported when using a likelihood function.'
+                         'Please re-instantiate the FiniteDPP object using the likelihood matrix eval_L(X_data).']
             raise ValueError('\n'.join(err_print))
 
         else:
@@ -748,8 +750,8 @@ class FiniteDPP:
             raise ValueError('\n'.join(err_print))
 
         elif self.eval_L is not None:
-            err_print = ['L = K(I-K)^-1 = kernel cannot be computed:',
-                         'L is provided in lazy mode and likely would not fit in memory']
+            err_print = ['Computing the L kernel is currently not supported when using a likelihood function.'
+                         'Please re-instantiate the FiniteDPP object using the likelihood matrix eval_L(X_data).']
             raise ValueError('\n'.join(err_print))
 
         else:

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -436,8 +436,35 @@ class FiniteDPP:
 
         self.sampling_mode = mode
 
+        if self.sampling_mode == 'vfx':
+            if self.eval_L is None or self.X_data is None:
+                raise ValueError("The vfx sampler is currently only available for the 'L_eval_X_data' representation.")
+
+            if (self.intermediate_sample_info is None
+                    or self.intermediate_sample_info.s != size):
+                self.intermediate_sample_info = vfx_sampling_precompute_constants(
+                    X=self.X_data,
+                    eval_L=self.eval_L,
+                    desired_s=size,
+                    rng=rng,
+                    **params
+                )
+
+                q_func = params.get('q_func', lambda s: s * s)
+                self.intermediate_sample_info = self.intermediate_sample_info._replace(
+                    q=q_func(self.intermediate_sample_info.s))
+
+            sampl = []
+            while len(sampl) != size:
+                sampl, rej_count = vfx_sampling_do_sampling_loop(self.X_data,
+                                                                 self.eval_L,
+                                                                 self.intermediate_sample_info,
+                                                                 rng)
+
+            self.list_of_samples.append(sampl)
+
         # If DPP defined via projection kernel
-        if self.projection:
+        elif self.projection:
             if self.kernel_type == 'correlation':
 
                 if self.K_eig_vals is not None:
@@ -492,30 +519,6 @@ class FiniteDPP:
                                                     random_state=rng)
 
             self.size_k_dpp = size
-            self.list_of_samples.append(sampl)
-
-        elif self.sampling_mode == 'vfx':
-            if (self.intermediate_sample_info is None
-                    or self.intermediate_sample_info.s != size):
-                self.intermediate_sample_info = vfx_sampling_precompute_constants(
-                    X = self.X,
-                    eval_L=self.eval_L,
-                    desired_s=size,
-                    rng = rng,
-                    **params
-                )
-
-                q_func = params.get('q_func', lambda s: s * s)
-                self.intermediate_sample_info = self.intermediate_sample_info._replace(
-                    q=q_func(self.intermediate_sample_info.s))
-
-            sampl = []
-            while len(sampl) != size:
-                sampl, rej_count = vfx_sampling_do_sampling_loop(self.X,
-                                                                  self.eval_L,
-                                                                  self.intermediate_sample_info,
-                                                                  rng)
-
             self.list_of_samples.append(sampl)
 
         # If eigen decoposition of K, L or L_dual is available USE IT!

--- a/dppy/finite_dpps.py
+++ b/dppy/finite_dpps.py
@@ -320,9 +320,10 @@ class FiniteDPP:
                                                                             q=q_func(self.intermediate_sample_info.s))
 
             sampl, rej_count = vfx_sampling_do_sampling_loop(self.X_data,
-                                                         self.eval_L,
-                                                         self.intermediate_sample_info,
-                                                         rng)
+                                                             self.eval_L,
+                                                             self.intermediate_sample_info,
+                                                             rng,
+                                                             **params)
             self.list_of_samples.append(sampl)
 
         # If eigen decoposition of K, L or L_dual is available USE IT!
@@ -459,12 +460,20 @@ class FiniteDPP:
                 self.intermediate_sample_info = self.intermediate_sample_info._replace(
                     q=q_func(self.intermediate_sample_info.s))
 
-            sampl = []
-            while len(sampl) != size:
+            max_iter_size_rejection = params.get('max_iter_size_rejection', 100)
+            for size_rejection_iter in range(max_iter_size_rejection):
                 sampl, rej_count = vfx_sampling_do_sampling_loop(self.X_data,
                                                                  self.eval_L,
                                                                  self.intermediate_sample_info,
-                                                                 rng)
+                                                                 rng,
+                                                                 **params)
+                if len(sampl) == size:
+                    break
+            else:
+                raise ValueError('The vfx sampler reached the maximum number of rejections allowed '
+                                 'for the k-DPP size rejection ({}), try to increase the q factor '
+                                 '(see q_func parameter) or the Nystrom approximation accuracy '
+                                 'see rls_oversample_* parameters).'.format(max_iter_size_rejection))
 
             self.list_of_samples.append(sampl)
 

--- a/dppy/vfx_sampling.py
+++ b/dppy/vfx_sampling.py
@@ -340,6 +340,6 @@ def vfx_sampling_do_sampling_loop(X,
     DPP.sample_exact(random_state=rng)
 
     S_tilda = np.array(DPP.list_of_samples)
-    S = sigma[S_tilda].flatten().tolist()
+    S = sigma[S_tilda].ravel().tolist()
 
     return S, rej_count

--- a/dppy/vfx_sampling.py
+++ b/dppy/vfx_sampling.py
@@ -26,7 +26,6 @@
 from dppy.bless import bless, Dictionary, estimate_rls
 from dppy.utils import stable_invert_root, evaluate_L_diagonal, get_progress_bar, check_random_state
 import numpy as np
-from dppy.finite_dpps import FiniteDPP
 from scipy.optimize import brentq
 from collections import namedtuple
 
@@ -328,6 +327,9 @@ def vfx_sampling_do_sampling_loop(X,
 
     E, U = np.linalg.eigh(L_tilda)
 
+    # this has to be here rather than at the top to avoid circular dependencies
+    # TODO: maybe refactor to avoid this
+    from dppy.finite_dpps import FiniteDPP
     DPP = FiniteDPP(kernel_type='likelihood', L_eig_dec=(E, U))
     DPP.sample_exact(random_state=rng)
 

--- a/dppy/vfx_sampling.py
+++ b/dppy/vfx_sampling.py
@@ -118,47 +118,13 @@ _PrecomputeState =\
                ['alpha_star', 'logdet_I_A', 'q', 's', 'z', 'rls_estimate'])
 
 
-def dpp_vfx(X,
-            eval_L,
-            rls_oversample_dppvfx=4,
-            rls_oversample_bless=4,
-            random_state=None,
-            return_pc_state=False,
-            desired_s=None,
-            H_bless=None,
-            q_func=lambda s: s * s):
-    """
-    .. todo::
-
-        - docstring: description of params and return, add types
-    """
-    rng = check_random_state(random_state)
-
-    precomputed_state = _precompute_constants(X,
-                                              eval_L,
-                                              rls_oversample_dppvfx,
-                                              rls_oversample_bless,
-                                              rng,
-                                              desired_s,
-                                              H_bless)
-
-    precomputed_state.q = q_func(precomputed_state.s)
-
-    S, rej_count = _sampling_loop(X, eval_L, precomputed_state, rng)
-
-    if return_pc_state:
-        return S, precomputed_state, rej_count
-    else:
-        return S
-
-
-def _precompute_constants(X,
-                          eval_L,
-                          rls_oversample_dppvfx,
-                          rls_oversample_bless,
-                          rng,
-                          desired_s,
-                          H_bless):
+def vfx_sampling_precompute_constants(X,
+                                      eval_L,
+                                      rng,
+                                      desired_s=None,
+                                      rls_oversample_dppvfx=4,
+                                      rls_oversample_bless=4,
+                                      H_bless=None):
     """
     .. todo::
 
@@ -284,11 +250,11 @@ def _precompute_constants(X,
     return result
 
 
-def _sampling_loop(X,
-                   eval_L,
-                   precomputed_state: _PrecomputeState,
-                   rng,
-                   verbose=True):
+def vfx_sampling_do_sampling_loop(X,
+                                  eval_L,
+                                  precomputed_state: _PrecomputeState,
+                                  rng,
+                                  verbose=True):
     """
     .. todo::
 
@@ -366,6 +332,6 @@ def _sampling_loop(X,
     DPP.sample_exact(random_state=rng)
 
     S_tilda = np.array(DPP.list_of_samples)
-    S = sigma[S_tilda]
+    S = sigma[S_tilda].tolist()
 
     return S, rej_count


### PR DESCRIPTION
Continuing the implementation of the associated paper at NeurIPS '19 on very fast and exact DPP sampling with intermediate sampling and Nystrom approximation.

Added docstrings for most new functions.

The code is ready to be tested e.g. using a shim likelihood function such as
```python
def linear_likelihood(X, Y=None):
    if Y is None:
        return X.dot(Y.T)
    else:
        return X.dot(X.T)
```